### PR TITLE
Update git repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.3",
   "author": "Stephen Whitmore <stephen.whitmore@gmail.com>",
   "repository": {
-    "url": "git://github.com/noffle/hyper-edit.git"
+    "url": "git://github.com/noffle/hyper-textarea.git"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should fix the repository link on https://www.npmjs.com/package/hyper-textarea after `npm publish`.